### PR TITLE
Adds HIER support

### DIFF
--- a/retro_data_structures/formats/hier.py
+++ b/retro_data_structures/formats/hier.py
@@ -1,4 +1,4 @@
-from construct import (Struct, Const, Int32ub, PrefixedArray)
+from construct import (Struct, Const, Int32ub, PrefixedArray, GreedyRange, Byte)
 
 from retro_data_structures.common_types import AssetId32, String
 
@@ -10,4 +10,5 @@ HIER = Struct(
         scan_id=AssetId32,
         parent_id=Int32ub,
     )),
+    junk=GreedyRange(Byte)
 )

--- a/retro_data_structures/formats/hier.py
+++ b/retro_data_structures/formats/hier.py
@@ -1,0 +1,13 @@
+from construct import (Struct, Const, Int32ub, PrefixedArray)
+
+from retro_data_structures.common_types import AssetId32, String
+
+HIER = Struct(
+    magic=Const(b"HIER"),
+    entries=PrefixedArray(Int32ub, Struct(
+        string_table_id=AssetId32,
+        name=String,
+        scan_id=AssetId32,
+        parent_id=Int32ub,
+    )),
+)

--- a/test/formats/test_cinf.py
+++ b/test/formats/test_cinf.py
@@ -1,6 +1,6 @@
 from retro_data_structures.formats.cinf import CINF
 from retro_data_structures.game_check import Game
-from test_lib import parse_and_build_compare
+from test.test_lib import parse_and_build_compare
 
 
 def test_compare_p1(prime1_pwe_project):

--- a/test/formats/test_cskr.py
+++ b/test/formats/test_cskr.py
@@ -1,6 +1,6 @@
 from retro_data_structures.formats.cskr import CSKR
 from retro_data_structures.game_check import Game
-from test_lib import parse_and_build_compare
+from test.test_lib import parse_and_build_compare
 
 
 def test_compare_p1(prime1_pwe_project):

--- a/test/formats/test_hier.py
+++ b/test/formats/test_hier.py
@@ -1,0 +1,8 @@
+from retro_data_structures.formats.hier import HIER
+from retro_data_structures.game_check import Game
+from test_lib import parse_and_build_compare
+
+def test_compare(prime2_pwe_project):
+    parse_and_build_compare(HIER, Game.ECHOES, prime2_pwe_project.joinpath(
+        "NoARAM/DUMB_ScanHierarchy.DUMB"
+    ))

--- a/test/formats/test_hier.py
+++ b/test/formats/test_hier.py
@@ -1,8 +1,8 @@
 from retro_data_structures.formats.hier import HIER
 from retro_data_structures.game_check import Game
-from test_lib import parse_and_build_compare
+from test.test_lib import parse_and_build_compare
 
 def test_compare(prime2_pwe_project):
     parse_and_build_compare(HIER, Game.ECHOES, prime2_pwe_project.joinpath(
-        "NoARAM/DUMB_ScanHierarchy.DUMB"
+        "Resources/NoARAM/DUMB_ScanHierarchy.DUMB"
     ))


### PR DESCRIPTION
Closes #2 

Gollop had already done this but it was failing the equivalency test because it didn't account for the few junk bytes at the end of the echoes HIER file; I added a field for that junk and fixed some of the tests that weren't running