### PR TITLE
adds SCAN format

### DIFF
--- a/retro_data_structures/dependencies.py
+++ b/retro_data_structures/dependencies.py
@@ -3,7 +3,7 @@ from typing import Iterator, Dict, Set, List, NamedTuple, Callable, Any
 
 from retro_data_structures.asset_provider import AssetProvider, UnknownAssetId, InvalidAssetId
 from retro_data_structures.conversion.asset_converter import AssetConverter
-from retro_data_structures.formats import ancs, cmdl, evnt, part, AssetId, AssetType
+from retro_data_structures.formats import scan, dgrp, ancs, cmdl, evnt, part, AssetId, AssetType
 from retro_data_structures.game_check import Game
 
 
@@ -38,6 +38,8 @@ _dependency_functions = {
     "ancs": ancs.dependencies_for,
     "evnt": evnt.dependencies_for,
     "part": part.dependencies_for,
+    "scan": scan.dependencies_for,
+    "dgrp": dgrp.dependencies_for,
 }
 
 

--- a/retro_data_structures/formats/__init__.py
+++ b/retro_data_structures/formats/__init__.py
@@ -34,7 +34,7 @@ ALL_FORMATS = {
     "CSPP": CSPP,
 
     "SCAN": SCAN,
-    "DGRP": DGRP
+    "DGRP": DGRP,
     "STRG": STRG,
 
 }

--- a/retro_data_structures/formats/__init__.py
+++ b/retro_data_structures/formats/__init__.py
@@ -1,16 +1,17 @@
 from construct import Construct
-
 from retro_data_structures.formats.ancs import ANCS
 from retro_data_structures.formats.anim import ANIM
 from retro_data_structures.formats.cinf import CINF
 from retro_data_structures.formats.cmdl import CMDL
 from retro_data_structures.formats.cskr import CSKR
 from retro_data_structures.formats.cspp import CSPP
+from retro_data_structures.formats.dgrp import DGRP
 from retro_data_structures.formats.evnt import EVNT
 from retro_data_structures.formats.mlvl import MLVL
 from retro_data_structures.formats.mrea import MREA
 from retro_data_structures.formats.pak import PAK
 from retro_data_structures.formats.part import PART
+from retro_data_structures.formats.scan import SCAN
 from retro_data_structures.formats.txtr import TXTR
 
 AssetType = str
@@ -30,6 +31,8 @@ ALL_FORMATS = {
     "PART": PART,
     "TXTR": TXTR,
     "CSPP": CSPP,
+    "SCAN": SCAN,
+    "DGRP": DGRP,
 }
 
 

--- a/retro_data_structures/formats/dgrp.py
+++ b/retro_data_structures/formats/dgrp.py
@@ -1,0 +1,14 @@
+from construct import Struct, Int32ub, PrefixedArray
+from retro_data_structures.common_types import FourCC
+from retro_data_structures.game_check import AssetIdCorrect, Game
+
+Dependency = Struct(
+    "asset_type" / FourCC,
+    "asset_id" / AssetIdCorrect
+)
+
+DGRP = PrefixedArray(Int32ub, Dependency)
+
+def dependencies_for(obj, target_game: Game):
+    for dependency in obj:
+        yield dependency.asset_type, dependency.asset_id

--- a/retro_data_structures/formats/scan.py
+++ b/retro_data_structures/formats/scan.py
@@ -2,14 +2,15 @@
 https://wiki.axiodl.com/w/SCAN_(File_Format)
 """
 
-from construct import (Array, Byte, Check, Const, Enum, Float32b, GreedyRange,
-                       Hex, IfThenElse, Int32ub, Struct)
+from construct import (Array, Byte, Check, Const, Enum, Flag, Float32b,
+                       GreedyRange, Hex, IfThenElse, Int32sb, Int32ub, Struct)
 from retro_data_structures import game_check
-from retro_data_structures.common_types import AssetId32, FourCC
+from retro_data_structures.common_types import AssetId32, FourCC, String
 from retro_data_structures.formats import dgrp
 from retro_data_structures.formats.dgrp import DGRP
 from retro_data_structures.formats.script_object import ScriptInstance
-from retro_data_structures.game_check import Game
+from retro_data_structures.game_check import AssetIdCorrect, Game
+from retro_data_structures.properties import AddPropertyInfo, SubProperties
 
 ScanImage = Struct(
     "texture" / AssetId32, #TXTR
@@ -41,6 +42,36 @@ Prime1SCAN = Struct(
     "scan_images" / Array(4, ScanImage),
     "junk" / GreedyRange(Byte)
 )
+
+# ScannableObjectInfo Properties
+AddPropertyInfo(0x2F5B6423, AssetIdCorrect, "STRG, Scan Text")
+AddPropertyInfo(0xC308A322, Int32sb, "Scan Speed (0 for fast, 1 for slow)")
+AddPropertyInfo(0x7B714814, Flag, "Is Important? (0 for blue, 1 for red)")
+AddPropertyInfo(0x1733B1EC, Flag, "Use Logbook Model After Scan?")
+AddPropertyInfo(0x53336141, AssetIdCorrect, "CMDL, Post-Scan Override Texture")
+AddPropertyInfo(0x3DE0BA64, Float32b, "Logbook Default X Rotation")
+AddPropertyInfo(0x2ADD6628, Float32b, "Logbook Default Z Rotation")
+AddPropertyInfo(0xD0C15066, Float32b, "Logbook Scale")
+AddPropertyInfo(0xB7ADC418, AssetIdCorrect, "CMDL, Logbook Model")
+AddPropertyInfo(0x15694EE1, Byte, "AnimationParameters, Logbook AnimSet")
+AddPropertyInfo(0x58F9FE99, Byte, "AnimationParameters, Unknown")
+AddPropertyInfo(0x1C5B4A3A, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
+AddPropertyInfo(0x1C5B4A3A, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
+AddPropertyInfo(0x8728A0EE, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
+AddPropertyInfo(0xF1CD99D3, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
+AddPropertyInfo(0x6ABE7307, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
+AddPropertyInfo(0x1C07EBA9, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
+AddPropertyInfo(0x8774017D, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
+AddPropertyInfo(0xF1913840, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
+AddPropertyInfo(0x6AE2D294, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
+AddPropertyInfo(0x1CE2091C, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
+# TODO: unknown prime 3 property 1
+# TODO: unknown prime 3 property 2
+
+# ScanInfoSecondaryModel Properties
+AddPropertyInfo(0x1F7921BC, AssetIdCorrect, "CMDL, Model")
+AddPropertyInfo(0xCDD202D1, Byte, "AnimationParameters, AnimSet")
+AddPropertyInfo(0x3EA2BED8, String, "Attach Bone Name")
 
 Prime23SCAN = Struct(
     "magic" / Const("SCAN", FourCC),

--- a/retro_data_structures/formats/scan.py
+++ b/retro_data_structures/formats/scan.py
@@ -1,0 +1,64 @@
+"""
+https://wiki.axiodl.com/w/SCAN_(File_Format)
+"""
+
+from construct import (Array, Byte, Check, Const, Enum, Float32b, GreedyRange,
+                       Hex, IfThenElse, Int32ub, Struct)
+from retro_data_structures import game_check
+from retro_data_structures.common_types import AssetId32, FourCC
+from retro_data_structures.formats import dgrp
+from retro_data_structures.formats.dgrp import DGRP
+from retro_data_structures.formats.script_object import ScriptInstance
+from retro_data_structures.game_check import Game
+
+ScanImage = Struct(
+    "texture" / AssetId32, #TXTR
+    "appearance_threshold" / Float32b,
+    Check(lambda this: this.appearance_threshold >= 0.0 and this.appearance_threshold <= 1.0),
+    "image_position" / Int32ub,
+    "width" / Int32ub,
+    "height" / Int32ub,
+    "interval" / Float32b,
+    "duration" / Float32b
+)
+
+Prime1SCAN = Struct(
+    "version" / Enum(Int32ub, demo=3, final=5),
+    "magic" / Hex(Const(0x0BADBEEF, Int32ub)),
+    "frame_id" / AssetId32, # FRME
+    "text_id" / AssetId32, # STRG
+    "scan_speed" / Enum(Int32ub, fast=0, slow=1),
+    "logbook_category" / Enum(
+        Int32ub,
+        none=0,
+        pirate=1,
+        chozo=2,
+        creatures=3,
+        research=4,
+        artifacts=5
+    ),
+    "scan_icon" / Enum(Byte, orange=0, red=1),
+    "scan_images" / Array(4, ScanImage),
+    "junk" / GreedyRange(Byte)
+)
+
+Prime23SCAN = Struct(
+    "magic" / Const("SCAN", FourCC),
+    "unknown1" / Const(2, Int32ub),
+    "unknown2" / Byte,
+    "instance_count" / Const(1, Int32ub),
+    "scannable_object_info" / ScriptInstance,
+    "dependencies" / DGRP,
+    "junk" / GreedyRange(Byte)
+)
+
+SCAN = IfThenElse(game_check.is_prime1, Prime1SCAN, Prime23SCAN)
+
+def dependencies_for(obj, target_game: Game):
+    if target_game == Game.PRIME:
+        yield "FRME", obj.frame_id
+        yield "STRG", obj.text_id
+        for image in obj.scan_images:
+            yield "TXTR", image.texture
+    else:
+        yield from dgrp.dependencies_for(obj.dependencies, target_game)

--- a/retro_data_structures/formats/script_object.py
+++ b/retro_data_structures/formats/script_object.py
@@ -1,154 +1,11 @@
-from typing import List, Any
+"""
+https://wiki.axiodl.com/w/Scriptable_Layers_(File_Format)
+"""
 
-import construct
-from construct import (Struct, Int32ub, Int32sb, Float32b, PrefixedArray, Int16ub, PaddedString, Hex,
-                       GreedyBytes, Prefixed, ExprAdapter, Flag)
-
-from retro_data_structures.common_types import FourCC, String
-
-
-class Property:
-    id: int
-
-    def __init__(self, property_id: int, data):
-        self.id = property_id
-        self.data = data
-
-    @classmethod
-    def from_raw(cls, raw: construct.Container) -> "Property":
-        return cls(raw.id, cls._decode_data(raw.data))
-
-    @classmethod
-    def _decode_data(cls, data: bytes) -> Any:
-        raise NotImplementedError()
-
-    @property
-    def to_raw(self):
-        return construct.Container(
-            id=self.id,
-            data=self._encode_data,
-        )
-
-    @property
-    def _encode_data(self):
-        raise NotImplementedError()
-
-    def __str__(self):
-        return f"{type(self).__name__} 0x{self.id:08x}: {self.data}"
-
-
-class GenericProperty(Property):
-    data: bytes
-
-    @classmethod
-    def _decode_data(cls, data: bytes):
-        return data
-
-    @property
-    def _encode_data(self):
-        return self.data
-
-
-PROPERTY_TYPES = {}
-
-ConstructProperty = ExprAdapter(
-    Struct(id=Hex(Int32ub), data=Prefixed(Int16ub, GreedyBytes)),
-    lambda obj, ctx: PROPERTY_TYPES.get(obj.id, GenericProperty).from_raw(obj),
-    lambda obj, ctx: obj.to_raw,
-)
-
-SubProperties = PrefixedArray(Int16ub, ConstructProperty)
-
-
-class StringProperty(Property):
-    data: str
-
-    @classmethod
-    def _decode_data(cls, data: bytes):
-        return String.parse(data)
-
-    @property
-    def _encode_data(self):
-        return String.build(self.data)
-
-
-class BoolProperty(Property):
-    data: bool
-
-    @classmethod
-    def _decode_data(cls, data: bytes):
-        return Flag.parse(data)
-
-    @property
-    def _encode_data(self):
-        return Flag.build(self.data)
-
-
-class IntProperty(Property):
-    data: int
-
-    @classmethod
-    def _decode_data(cls, data: bytes):
-        return Int32sb.parse(data)
-
-    @property
-    def _encode_data(self):
-        return Int32sb.build(self.data)
-
-
-class FloatProperty(Property):
-    data: float
-
-    @classmethod
-    def _decode_data(cls, data: bytes):
-        return Float32b.parse(data)
-
-    @property
-    def _encode_data(self):
-        return Float32b.build(self.data)
-
-
-class StructProperty(Property):
-    data: List[Property]
-
-    @classmethod
-    def _decode_data(cls, data: bytes):
-        return SubProperties.parse(data)
-
-    @property
-    def _encode_data(self):
-        return SubProperties.build(self.data)
-
-    def by_id(self, the_id: int) -> Property:
-        for p in self.data:
-            if p.id == the_id:
-                return p
-        raise KeyError(f"Id not found: {the_id}")
-
-    @property
-    def properties(self):
-        return self.data
-
-
-
-PROPERTY_TYPES.update({
-    0x255A4580: StructProperty,
-    0x494E414D: StringProperty,
-    0x41435456: BoolProperty,
-    0xB581574B: IntProperty,
-    0x95F8D644: IntProperty,
-    0x3FA164BC: IntProperty,
-    0xDE3E40A3: IntProperty,
-    0xD3AF8D72: IntProperty,
-    0x8DB9398A: IntProperty,
-    0x03BDEA98: IntProperty,
-    0x70729364: IntProperty,
-    0xCEC16932: StructProperty,
-    0xE709DDC0: StructProperty,
-    0x49614C51: StructProperty,
-    0xB498B424: StructProperty,
-    0xFFFFFFFF: StructProperty,
-})
+from construct import (Hex, Int16ub, Int32ub, PaddedString, Pointer,
+                       PrefixedArray, Rebuild, Seek, Struct, Tell, this)
+from retro_data_structures.common_types import FourCC
+from retro_data_structures.properties import Property
 
 Connection = Struct(
     state=PaddedString(4, "ascii"),
@@ -157,9 +14,13 @@ Connection = Struct(
 )
 
 ScriptInstance = Struct(
-    type=FourCC,
-    size=Int16ub,  # TODO: calculate. Size in bytes starting after this field.
-    id=Hex(Int32ub),
-    connections=PrefixedArray(Int16ub, Connection),
-    properties=ConstructProperty,
+    "type" / FourCC,
+    "_size_start" / Tell,
+    Seek(Int16ub.sizeof(), 1),
+    "_start" / Tell,
+    "id" / Hex(Int32ub),
+    "connections" / PrefixedArray(Int16ub, Connection),
+    "properties" / Property,
+    "_end" / Tell,
+    "size" / Pointer(this._size_start, Rebuild(Int16ub, this._end - this._start))
 )

--- a/retro_data_structures/properties.py
+++ b/retro_data_structures/properties.py
@@ -38,3 +38,32 @@ AddPropertyInfo(0x49614C51, SubProperties)
 AddPropertyInfo(0xB498B424, SubProperties)
 AddPropertyInfo(0xFFFFFFFF, SubProperties, "Base property struct")
 
+# ScannableObjectInfo Properties
+AddPropertyInfo(0x2F5B6423, AssetIdCorrect, "STRG, Scan Text")
+AddPropertyInfo(0xC308A322, Int32sb, "Scan Speed (0 for fast, 1 for slow)")
+AddPropertyInfo(0x7B714814, Flag, "Is Important? (0 for blue, 1 for red)")
+AddPropertyInfo(0x1733B1EC, Flag, "Use Logbook Model After Scan?")
+AddPropertyInfo(0x53336141, AssetIdCorrect, "CMDL, Post-Scan Override Texture")
+AddPropertyInfo(0x3DE0BA64, Float32b, "Logbook Default X Rotation")
+AddPropertyInfo(0x2ADD6628, Float32b, "Logbook Default Z Rotation")
+AddPropertyInfo(0xD0C15066, Float32b, "Logbook Scale")
+AddPropertyInfo(0xB7ADC418, AssetIdCorrect, "CMDL, Logbook Model")
+AddPropertyInfo(0x15694EE1, Byte, "AnimationParameters, Logbook AnimSet")
+AddPropertyInfo(0x58F9FE99, Byte, "AnimationParameters, Unknown")
+AddPropertyInfo(0x1C5B4A3A, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
+AddPropertyInfo(0x1C5B4A3A, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
+AddPropertyInfo(0x8728A0EE, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
+AddPropertyInfo(0xF1CD99D3, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
+AddPropertyInfo(0x6ABE7307, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
+AddPropertyInfo(0x1C07EBA9, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
+AddPropertyInfo(0x8774017D, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
+AddPropertyInfo(0xF1913840, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
+AddPropertyInfo(0x6AE2D294, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
+AddPropertyInfo(0x1CE2091C, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
+# TODO: unknown prime 3 property 1
+# TODO: unknown prime 3 property 2
+
+# ScanInfoSecondaryModel Properties
+AddPropertyInfo(0x1F7921BC, AssetIdCorrect, "CMDL, Model")
+AddPropertyInfo(0xCDD202D1, Byte, "AnimationParameters, AnimSet")
+AddPropertyInfo(0x3EA2BED8, String, "Attach Bone Name")

--- a/retro_data_structures/properties.py
+++ b/retro_data_structures/properties.py
@@ -1,0 +1,40 @@
+from construct import (Byte, Computed, Flag, Float32b, GreedyRange, Hex,
+                       Int16ub, Int32sb, Int32ub, Prefixed, PrefixedArray,
+                       Struct, Switch, this)
+
+from retro_data_structures.common_types import String
+from retro_data_structures.game_check import AssetIdCorrect
+
+PROPERTY_INFO = {}
+PROPERTY_TYPES = {}
+
+Property = Struct(
+    "id" / Hex(Int32ub),
+    "data" / Prefixed(Int16ub, GreedyRange(Switch(this.id, PROPERTY_TYPES, Byte))),
+    "comment" / Computed(lambda this: PROPERTY_INFO.get(this.id, "Unknown property"))
+)
+
+SubProperties = PrefixedArray(Int16ub, Property)
+
+def AddPropertyInfo(_id, data_type, comment=""):
+    PROPERTY_TYPES[_id] = data_type
+    PROPERTY_INFO[_id] = comment
+
+# TODO: add missing comments
+AddPropertyInfo(0x255A4580, SubProperties, "EditorProperties")
+AddPropertyInfo(0x494E414D, String)
+AddPropertyInfo(0x41435456, Flag)
+AddPropertyInfo(0xB581574B, Int32sb)
+AddPropertyInfo(0x95F8D644, Int32sb)
+AddPropertyInfo(0x3FA164BC, Int32sb)
+AddPropertyInfo(0xDE3E40A3, Int32sb)
+AddPropertyInfo(0xD3AF8D72, Int32sb)
+AddPropertyInfo(0x8DB9398A, Int32sb)
+AddPropertyInfo(0x03BDEA98, Int32sb)
+AddPropertyInfo(0x70729364, Int32sb)
+AddPropertyInfo(0xCEC16932, SubProperties)
+AddPropertyInfo(0xE709DDC0, SubProperties)
+AddPropertyInfo(0x49614C51, SubProperties)
+AddPropertyInfo(0xB498B424, SubProperties)
+AddPropertyInfo(0xFFFFFFFF, SubProperties, "Base property struct")
+

--- a/retro_data_structures/properties.py
+++ b/retro_data_structures/properties.py
@@ -37,33 +37,3 @@ AddPropertyInfo(0xE709DDC0, SubProperties)
 AddPropertyInfo(0x49614C51, SubProperties)
 AddPropertyInfo(0xB498B424, SubProperties)
 AddPropertyInfo(0xFFFFFFFF, SubProperties, "Base property struct")
-
-# ScannableObjectInfo Properties
-AddPropertyInfo(0x2F5B6423, AssetIdCorrect, "STRG, Scan Text")
-AddPropertyInfo(0xC308A322, Int32sb, "Scan Speed (0 for fast, 1 for slow)")
-AddPropertyInfo(0x7B714814, Flag, "Is Important? (0 for blue, 1 for red)")
-AddPropertyInfo(0x1733B1EC, Flag, "Use Logbook Model After Scan?")
-AddPropertyInfo(0x53336141, AssetIdCorrect, "CMDL, Post-Scan Override Texture")
-AddPropertyInfo(0x3DE0BA64, Float32b, "Logbook Default X Rotation")
-AddPropertyInfo(0x2ADD6628, Float32b, "Logbook Default Z Rotation")
-AddPropertyInfo(0xD0C15066, Float32b, "Logbook Scale")
-AddPropertyInfo(0xB7ADC418, AssetIdCorrect, "CMDL, Logbook Model")
-AddPropertyInfo(0x15694EE1, Byte, "AnimationParameters, Logbook AnimSet")
-AddPropertyInfo(0x58F9FE99, Byte, "AnimationParameters, Unknown")
-AddPropertyInfo(0x1C5B4A3A, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
-AddPropertyInfo(0x1C5B4A3A, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
-AddPropertyInfo(0x8728A0EE, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
-AddPropertyInfo(0xF1CD99D3, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
-AddPropertyInfo(0x6ABE7307, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
-AddPropertyInfo(0x1C07EBA9, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
-AddPropertyInfo(0x8774017D, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
-AddPropertyInfo(0xF1913840, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
-AddPropertyInfo(0x6AE2D294, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
-AddPropertyInfo(0x1CE2091C, SubProperties, "ScanInfoSecondaryModel, Secondary Model 1")
-# TODO: unknown prime 3 property 1
-# TODO: unknown prime 3 property 2
-
-# ScanInfoSecondaryModel Properties
-AddPropertyInfo(0x1F7921BC, AssetIdCorrect, "CMDL, Model")
-AddPropertyInfo(0xCDD202D1, Byte, "AnimationParameters, AnimSet")
-AddPropertyInfo(0x3EA2BED8, String, "Attach Bone Name")

--- a/test/formats/test_scan.py
+++ b/test/formats/test_scan.py
@@ -1,0 +1,21 @@
+from retro_data_structures import dependencies
+from retro_data_structures.asset_provider import AssetProvider
+from retro_data_structures.formats.scan import SCAN
+from retro_data_structures.game_check import Game
+
+from test.test_lib import parse_and_build_compare
+
+def test_compare_p1(prime1_pwe_project):
+    parse_and_build_compare(SCAN, Game.PRIME, prime1_pwe_project.joinpath(
+        "Resources/Uncategorized/Chozo Lore 002.SCAN"
+    ))
+
+def test_compare_p2(prime2_pwe_project):
+    parse_and_build_compare(SCAN, Game.ECHOES, prime2_pwe_project.joinpath(
+        "Resources/Uncategorized/Brizgee_0.SCAN"
+    ))
+
+def test_compare_p3(prime3_pwe_project):
+    parse_and_build_compare(SCAN, Game.CORRUPTION, prime3_pwe_project.joinpath(
+        "Resources/uncategorized/Your PED Suit will allow you to absorb this Phazon.SCAN"
+    ))


### PR DESCRIPTION
SCAN works (both Prime and Echoes> formats)

I ended up significantly simplifying the handling of Properties in scriptable objects as well, and added some functionality to em. scriptable objects also recalculate their size properly now