### PR TITLE
Remove Unneeded EVNT in TempleKeys

### DIFF
--- a/retro_data_structures/conversion/ancs.py
+++ b/retro_data_structures/conversion/ancs.py
@@ -133,6 +133,9 @@ def convert_from_echoes(data: Resource, details: AssetDetails, converter: AssetC
         if character["frozen_skin"] == 0xFFFFFFFF:
             character["frozen_skin"] = 0
 
+    if details.asset_id == 0x41C2513F:
+        del data["animation_set"]["event_sets"][1]
+
     _convert_meta_animations(data, converter, Game.ECHOES)
 
     data["animation_set"]["animation_resources"] = []


### PR DESCRIPTION
All items except TempleKeys use a single EVNT.  The extra EVNT contains no actual useful event set data.  This removes the unneeded one, preventing a possible incorrect selection of the EVNT ID/reference by other dependencies.