### PR TITLE
Fixed corruption ScriptObject templates

### DIFF
--- a/parse_pwe_templates.py
+++ b/parse_pwe_templates.py
@@ -1114,7 +1114,7 @@ class PooledString(BaseProperty):
         create_all_file(core_path.joinpath("__init__.py"), base_import, modules)
         return
 
-    if game_id in ["Prime", "Echoes"]:
+    if game_id in ["Prime", "Echoes", "Corruption"]:
         format_specifier = "L"
         known_size = 12
     else:
@@ -1542,12 +1542,12 @@ def parse_game(templates_path: Path, game_xml: Path, game_id: str) -> dict:
             null_byte = repr(b"\x00")
             if game_id == "Prime":
                 # No property size for Prime 1
-                parse_code = f'b"".join(iter(lambda: data.read(1), {null_byte})).decode("utf-8")'
+                parse_code = f'b"".join(iter(lambda: data.read(1), {null_byte})).decode("iso-8859-1")'
             else:
-                parse_code = 'data.read(property_size)[:-1].decode("utf-8")'
+                parse_code = 'data.read(property_size)[:-1].decode("iso-8859-1")'
             build_code.extend(
                 [
-                    'data.write({obj}.encode("utf-8"))',
+                    'data.write({obj}.encode("iso-8859-1"))',
                     f"data.write({null_byte})",
                 ]
             )

--- a/tests/formats/test_mrea.py
+++ b/tests/formats/test_mrea.py
@@ -53,6 +53,7 @@ def test_compare_p3(prime3_asset_manager, mrea_asset_id: AssetId):
     decoded = Mrea.parse(resource.data, target_game=prime3_asset_manager.target_game)
     for instance in _all_instances(decoded):
         assert isinstance(instance, ScriptInstance)
+        instance.type.from_bytes(instance.raw_properties)
 
     encoded = decoded.build()
 


### PR DESCRIPTION
- updated RSOT to reorder some properties
- changed string encoding to iso-8859-1
  - two Relays in Elysia - Skytram East contain the tm character (0x99)
  - some strings contain raw data (FluidProperties.FluidLockString)
- MREA p3 tests parse/build all SCLY

Note: It does parse/build every MREA but it may not cover all possible values. iso-8859-1 has some bytes without proper encodings, and it seems like strings are actually bytestrings in engine. It's likely not to be required outside of niche romhack usage, and since it's a superset of ASCII it should suffice for most use cases. 