### PR TITLE
make EnumAdapter gracefully handle values that aren't in the enum

### DIFF
--- a/src/retro_data_structures/adapters/enum_adapter.py
+++ b/src/retro_data_structures/adapters/enum_adapter.py
@@ -9,12 +9,31 @@ E = typing.TypeVar("E", bound=enum.IntEnum)
 
 
 class EnumAdapter[T: enum.IntEnum](construct.Adapter):
-    def __init__(self, enum_class: type[T], subcon=construct.Int32ub):
+    def __init__(
+        self,
+        enum_class: type[T],
+        subcon: construct.Construct = construct.Int32ub,
+        *,
+        strict: bool = False,
+    ):
         super().__init__(construct.Enum(subcon, enum_class))
         self._enum_class = enum_class
+        self.strict = strict
 
-    def _decode(self, obj: str, context, path) -> T:
-        return self._enum_class[obj]
+    def _handle_invalid[InvalidT](self, obj: InvalidT) -> InvalidT:
+        if self.strict:
+            raise ValueError(f"Invalid value for {self._enum_class.__name__}: {obj}")
+        else:
+            return obj
 
-    def _encode(self, obj: T, context, path) -> str:
-        return obj.name
+    def _decode(self, obj: str | int, context: construct.Container, path: str) -> T | int:
+        try:
+            return self._enum_class[obj]
+        except KeyError:
+            return self._handle_invalid(obj)
+
+    def _encode(self, obj: T | int, context: construct.Container, path: str) -> str | int:
+        try:
+            return self._enum_class(obj).name
+        except ValueError:
+            return self._handle_invalid(obj)

--- a/src/retro_data_structures/formats/mapa.py
+++ b/src/retro_data_structures/formats/mapa.py
@@ -112,8 +112,8 @@ _MappableObjectConstruct = construct.Struct(
     type=construct.Switch(
         get_current_game,
         {
-            Game.PRIME: EnumAdapter(ObjectTypeMP1),
-            Game.ECHOES: EnumAdapter(ObjectTypeMP2),
+            Game.PRIME: EnumAdapter(ObjectTypeMP1, construct.Int32sb),
+            Game.ECHOES: EnumAdapter(ObjectTypeMP2, construct.Int32sb),
         },
         default=construct.Int32sb,
     ),

--- a/tests/construct_extensions/test_enum_adapter.py
+++ b/tests/construct_extensions/test_enum_adapter.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import struct
+from enum import IntEnum
+
+import pytest
+
+from retro_data_structures.adapters.enum_adapter import EnumAdapter
+
+
+def test_enum_adapter():
+    # setup
+    class SomeEnum(IntEnum):
+        foo = 0
+        bar = 1
+
+    valid_in_value = struct.pack(">L", SomeEnum.foo)
+    invalid_in_value = struct.pack(">L", 3)
+
+    # test strict adapter, invalid data
+    strict = EnumAdapter(SomeEnum, strict=True)
+    with pytest.raises(ValueError, match="Invalid value for SomeEnum: 3"):
+        parse_result = strict.parse(invalid_in_value)
+    with pytest.raises(ValueError, match="Invalid value for SomeEnum: 3"):
+        build_result = strict.build(3)
+
+    # test non-strict adapter, invalid data
+    non_strict = EnumAdapter(SomeEnum, strict=False)
+    parse_result = non_strict.parse(invalid_in_value)
+    assert parse_result == 3
+    build_result = non_strict.build(3)
+    assert build_result == invalid_in_value
+
+    # test both with valid data
+    for adapter in (strict, non_strict):
+        parse_result = adapter.parse(valid_in_value)
+        assert parse_result is SomeEnum.foo
+        build_result = adapter.build(SomeEnum.foo)
+        assert build_result == valid_in_value


### PR DESCRIPTION
previous behavior was to silently build as 0, which is bad. I went with non-strict as the default because I'm not sure which uses of EnumAdapter may currently rely on supporting non-enum values. certainly MAPA does. also fixes MAPA to support signed values for object_type again