### PR TITLE
Don't decode properties in build_module_dependencies

### DIFF
--- a/src/retro_data_structures/formats/script_layer.py
+++ b/src/retro_data_structures/formats/script_layer.py
@@ -261,7 +261,7 @@ class ScriptLayer:
         #  meaning it will never remove an entry
         rels = list(self.module_dependencies)
         for instance in self.instances:
-            rels.extend(instance.get_properties().modules())
+            rels.extend(instance.script_type.modules())
 
         yield from list(dict.fromkeys(rels))
 


### PR DESCRIPTION
Faster and the module list doesn't depend on the data, just type