### PR TITLE
ignore target layer index when removing connections

### DIFF
--- a/src/retro_data_structures/formats/script_layer.py
+++ b/src/retro_data_structures/formats/script_layer.py
@@ -152,7 +152,7 @@ class ScriptLayer:
     def _get_instance_by_id(self, instance_id: InstanceIdRef) -> ScriptInstance:
         instance_id = resolve_instance_id(instance_id)
         for instance in self.instances:
-            if instance.id_matches(instance_id):
+            if instance.id.matches(instance_id):
                 return instance
         raise KeyError(instance_id)
 

--- a/src/retro_data_structures/formats/script_object.py
+++ b/src/retro_data_structures/formats/script_object.py
@@ -76,6 +76,14 @@ class InstanceId(int):
     def instance(self) -> int:
         return self & 0xFFFF
 
+    @property
+    def without_layer(self) -> InstanceId:
+        return InstanceId.new(0, self.area, self.instance)
+
+    def matches(self, other: InstanceId) -> bool:
+        """Compare two `InstanceId`s, ignoring any differences in their layer index."""
+        return self.without_layer == other.without_layer
+
 
 @dataclasses.dataclass(frozen=True)
 class Connection:
@@ -97,6 +105,10 @@ class Connection:
             message=self.message.value,
             target=self.target,
         )
+
+    def matches(self, other: Connection) -> bool:
+        """Compare two `Connection`s, ignoring differences in their target's layer index."""
+        return self.state == other.state and self.message == other.message and self.target.matches(other.target)
 
 
 @dataclasses.dataclass()
@@ -279,10 +291,6 @@ class ScriptInstance:
         self._raw.id = InstanceId(value)
         self.on_modify()
 
-    def id_matches(self, other: InstanceIdRef) -> bool:
-        other = resolve_instance_id(other)
-        return self.id.area == other.area and self.id.instance == other.instance
-
     @property
     def name(self) -> str:
         if self.target_game == Game.ECHOES:
@@ -385,7 +393,7 @@ class ScriptInstance:
         """
         old = self.connections
         old_size = len(old)
-        new = [c for c in old if c != connection]
+        new = [c for c in old if not c.matches(connection)]
         if old_size == len(new):
             raise KeyError(f"Connection {connection} not found")
         self.connections = new
@@ -393,7 +401,7 @@ class ScriptInstance:
     def remove_all_connections_to(self, target: InstanceIdRef) -> None:
         """Remove all connections that goes from `self` to an object with id `target`."""
         target = resolve_instance_id(target)
-        self.connections = [c for c in self.connections if c.target != target]
+        self.connections = [c for c in self.connections if not c.target.matches(target)]
 
     def replace_connections_to(self, original: InstanceIdRef, target: InstanceIdRef) -> None:
         """
@@ -409,7 +417,7 @@ class ScriptInstance:
 
         def _replace(c: Connection) -> Connection:
             nonlocal found
-            if c.target == original_:
+            if c.target.matches(original_):
                 found = True
                 return dataclasses.replace(c, target=target_)
             return c

--- a/tests/formats/test_script_api.py
+++ b/tests/formats/test_script_api.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
+
 import retro_data_structures.enums.echoes as _echoes_enums
 import retro_data_structures.enums.prime as _prime_enums
-
 from retro_data_structures.formats import script_object
 from retro_data_structures.formats.script_layer import SCLY
-from retro_data_structures.formats.script_object import InstanceId
+from retro_data_structures.formats.script_object import Connection, InstanceId
 from retro_data_structures.game_check import Game
 
 if TYPE_CHECKING:
@@ -276,6 +276,33 @@ def test_replace_connections_to(prime2_asset_manager):
     assert set(timer.connections) != set(original_connections)
     assert len(timer.connections) == len(original_connections)
     assert effect_targets_before == effect_targets_after - 2
+
+
+def test_compare_connection_without_layer_index(prime2_area: Area):
+    pickup = prime2_area.get_instance("Pickup Object")
+
+    assert len(pickup.connections) == 4
+
+    pickup.remove_connection(
+        Connection(
+            _echoes_enums.State.Arrived,
+            _echoes_enums.Message.SetToZero,
+            InstanceId(0x10450070),  # Post Pickup (wrong layer id)
+        )
+    )
+    assert len(pickup.connections) == 3
+
+    pickup.remove_all_connections_to(0x10450071)  # FadeIn/Out Long (wrong layer id)
+    assert len(pickup.connections) == 2
+
+    pickup.replace_connections_to(
+        original=0x1045006C,  # Deactivate Pickup (wrong layer id)
+        target=0x1045006D,  # Pickup Sound (wrong layer id)
+    )
+
+    pickup.connections
+    sound = prime2_area.get_instance("Pickup Sound")
+    assert all(conn.target.matches(sound.id) for conn in pickup.connections)
 
 
 @pytest.mark.xfail(reason="Prime 1 SCLY building is incorrect")

--- a/tests/formats/test_script_api.py
+++ b/tests/formats/test_script_api.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
-
 import retro_data_structures.enums.echoes as _echoes_enums
 import retro_data_structures.enums.prime as _prime_enums
+
 from retro_data_structures.formats import script_object
 from retro_data_structures.formats.script_layer import SCLY
 from retro_data_structures.formats.script_object import Connection, InstanceId


### PR DESCRIPTION
I believe this is the cause of https://github.com/randovania/open-prime-rando/issues/265. This means we're using the same comparison here as we use for `get_instance()`, which I think is more consistent. 