### PR TITLE
Script Object generation improvements

### DIFF
--- a/parse_pwe_templates.py
+++ b/parse_pwe_templates.py
@@ -57,11 +57,11 @@ def _get_struct(endianness: typing.Literal[">", "<"], fmt: str) -> str:
 
 def struct_unpack(endianness: typing.Literal[">", "<"], fmt: str) -> str:
     final_fmt = endianness + fmt
-    return f'structs.{_get_struct(endianness, fmt)}.unpack(data.read({struct.calcsize(final_fmt)}))'
+    return f"structs.{_get_struct(endianness, fmt)}.unpack(data.read({struct.calcsize(final_fmt)}))"
 
 
 def struct_pack(endianness: typing.Literal[">", "<"], fmt: str, code: str) -> str:
-    return f'structs.{_get_struct(endianness, fmt)}.pack({code})'
+    return f"structs.{_get_struct(endianness, fmt)}.pack({code})"
 
 
 _CODE_PARSE_UINT16 = {
@@ -136,7 +136,7 @@ class EnumDefinition:
         code += f"        return cls({_CODE_PARSE_UINT32[endianness]})\n"
 
         code += "\n    def to_stream(self, data: typing.BinaryIO) -> None:\n"
-        code += f'        data.write({struct_pack(endianness, "L", "self.value")})\n'
+        code += f"        data.write({struct_pack(endianness, 'L', 'self.value')})\n"
 
         code += "\n    @classmethod\n"
         code += "    def from_json(cls, data: json_util.JsonValue) -> typing_extensions.Self:\n"
@@ -592,7 +592,7 @@ class ClassDefinition:
             if prop.known_size is None:
                 build_prop.append("after = data.tell()")
                 build_prop.append("data.seek(before)")
-                build_prop.append(f'data.write({struct_pack(endianness, "H", "after - before - 2")})')
+                build_prop.append(f"data.write({struct_pack(endianness, 'H', 'after - before - 2')})")
                 build_prop.append("data.seek(after)")
 
             if not prop.custom_cook_pref:
@@ -703,7 +703,7 @@ class ClassDefinition:
                 variable_name += "_"
 
             # yield "    data.read(6)"  # TODO: assert correct
-            yield f'    property_id, property_size = {struct_unpack(endianness, "LH")}'
+            yield f"    property_id, property_size = {struct_unpack(endianness, 'LH')}"
             yield f"    assert property_id == 0x{prop.id:08x}"
             yield f"    {variable_name} = {prop.parse_code}"
             yield ""
@@ -732,9 +732,7 @@ class ClassDefinition:
             return
 
         if self.is_struct:
-            self.class_code += (
-                f'        struct_id, size, property_count = {struct_unpack(endianness, "LHH")}\n'
-            )
+            self.class_code += f"        struct_id, size, property_count = {struct_unpack(endianness, 'LHH')}\n"
             self.class_code += "        assert struct_id == 0xFFFFFFFF\n"
             self.class_code += "        root_size_start = data.tell() - 2\n\n"
         else:
@@ -786,15 +784,14 @@ class ClassDefinition:
             if prop.parse_code.endswith(".from_stream(data, property_size)"):
                 suffix_size = len("(data, property_size)")
                 decode_names[prop_name] = prop.parse_code[:-suffix_size]
+            elif prop.parse_code.startswith("structs.") and prop.parse_code.endswith("[0]"):
+                split_code = prop.parse_code.split(".", 2)
+                _DECODE_METHODS["decode_" + split_code[1]] = f"return {split_code[1]}.{split_code[2]}"
+                decode_names[prop_name] = f"structs.decode_{split_code[1]}"
             else:
-                if prop.parse_code.startswith("structs.") and prop.parse_code.endswith("[0]"):
-                    split_code = prop.parse_code.split(".", 2)
-                    _DECODE_METHODS["decode_" + split_code[1]] = f"return {split_code[1]}.{split_code[2]}"
-                    decode_names[prop_name] = f"structs.decode_{split_code[1]}"
-                else:
-                    decode_names[prop_name] = f"_decode_{prop_name}"
-                    self.after_class_code += f"def _decode_{prop_name}({signature}) -> {prop.prop_type}:\n"
-                    self.after_class_code += f"    return {prop.parse_code}\n\n\n"
+                decode_names[prop_name] = f"_decode_{prop_name}"
+                self.after_class_code += f"def _decode_{prop_name}({signature}) -> {prop.prop_type}:\n"
+                self.after_class_code += f"    return {prop.parse_code}\n\n\n"
 
         decoder_type = "typing.Callable[[typing.BinaryIO, int], typing.Any]"
         self.after_class_code += f"_property_decoder: dict[int, tuple[str, {decoder_type}]] = {{\n"
@@ -1487,7 +1484,7 @@ def parse_game(templates_path: Path, game_xml: Path, game_id: str) -> dict:
                 prop_type = "int"
                 field_params["default"] = repr(default_value)
                 parse_code = _CODE_PARSE_UINT32[endianness]
-                build_code.append(f'data.write({struct_pack(endianness, "L", "{obj}")})')
+                build_code.append(f"data.write({struct_pack(endianness, 'L', '{obj}')})")
                 from_json_code = "{obj}"
                 to_json_code = "{obj}"
 
@@ -1520,7 +1517,7 @@ def parse_game(templates_path: Path, game_xml: Path, game_id: str) -> dict:
                 comment = "Flagset"
                 field_params["default"] = default_value
                 parse_code = _CODE_PARSE_UINT32[endianness]
-                build_code.append(f'data.write({struct_pack(endianness, "L", "{obj}")})')
+                build_code.append(f"data.write({struct_pack(endianness, 'L', '{obj}')})")
                 from_json_code = "{obj}"
                 to_json_code = "{obj}"
 
@@ -1555,7 +1552,7 @@ def parse_game(templates_path: Path, game_xml: Path, game_id: str) -> dict:
                     format_specifier = "Q"
 
                 parse_code = struct_unpack(endianness, format_specifier) + "[0]"
-                build_code.append(f"data.write({struct_pack(endianness, format_specifier, "{obj}")})")
+                build_code.append(f"data.write({struct_pack(endianness, format_specifier, '{obj}')})")
                 from_json_code = "{obj}"
                 to_json_code = "{obj}"
 
@@ -1655,7 +1652,7 @@ def parse_game(templates_path: Path, game_xml: Path, game_id: str) -> dict:
             format_specifier = literal_prop.struct_format
 
             parse_code = struct_unpack(endianness, format_specifier) + "[0]"
-            build_code.append(f'data.write({struct_pack(endianness, format_specifier, "{obj}")})')
+            build_code.append(f"data.write({struct_pack(endianness, format_specifier, '{obj}')})")
             from_json_code = "{obj}"
             to_json_code = "{obj}"
 

--- a/parse_pwe_templates.py
+++ b/parse_pwe_templates.py
@@ -469,6 +469,9 @@ def _get_default(field_params: dict) -> str:
     return default_value
 
 
+_ALL_CLASS_DEFS: dict[str, dict[str, ClassDefinition]] = collections.defaultdict(dict)
+
+
 @dataclasses.dataclass
 class ClassDefinition:
     game_id: str
@@ -493,6 +496,9 @@ class ClassDefinition:
     need_enums: bool = False
     local_enums: list[EnumDefinition] = dataclasses.field(default_factory=list)
     has_custom_cook_pref: bool = False
+
+    def __post_init__(self):
+        _ALL_CLASS_DEFS[self.game_id][self.raw_name] = self
 
     @property
     def atomic(self) -> bool:
@@ -912,6 +918,9 @@ class ClassDefinition:
 
         self.class_code += "        }\n"
 
+    def has_dependency_code(self) -> bool:
+        return any(prop.dependency_code is not None for prop in self.all_props.values())
+
     def write_dependencies(self) -> None:
         if self.keep_unknown_properties() or self.game_id not in {"Prime", "Echoes"}:
             return
@@ -923,8 +932,6 @@ class ClassDefinition:
             if prop.dependency_code is None:
                 continue
 
-            has_dep = True
-
             prop_code = prop.dependency_code.format(obj=f"self.{prop_name}")
             if prop.dependency_code == "{obj}.dependencies_for(asset_manager)":
                 method_name[prop_name] = f"self.{prop_name}.dependencies_for"
@@ -933,7 +940,7 @@ class ClassDefinition:
                     self.needed_imports["retro_data_structures.base_resource"] = "Dependency"
                     prop_code = f"for it in {prop_code}:\n            yield Dependency(it.type, it.id, True)"
                 else:
-                    prop_code = f"yield from {prop_code}"
+                    prop_code = f"return {prop_code}"
 
                 method_name[prop_name] = f"self._dependencies_for_{prop_name}"
 
@@ -944,7 +951,7 @@ class ClassDefinition:
         self.typing_imports["retro_data_structures.asset_manager"] = "AssetManager"
         self.typing_imports["retro_data_structures.base_resource"] = "Dependency"
 
-        if has_dep:
+        if len(method_name) > 1:
             method_list = "\n".join(
                 f'            ({method_name[prop_name]}, "{prop_name}", "{prop.prop_type}"),'
                 for prop_name, prop in self.all_props.items()
@@ -964,9 +971,14 @@ class ClassDefinition:
                 )
 """
         else:
-            self.class_code += """
+            if not method_name:
+                single_method = "yield from []"
+            else:
+                single_method = f"return {list(method_name.values())[0]}(asset_manager)"
+
+            self.class_code += f"""
     def dependencies_for(self, asset_manager: AssetManager) -> typing.Iterator[Dependency]:
-        yield from []
+        {single_method}
 """
 
 
@@ -1320,6 +1332,20 @@ def parse_game(templates_path: Path, game_xml: Path, game_id: str) -> dict:
     _ensure_is_generated_dir(core_path)
     _add_default_types(core_path, game_id)
 
+    print("> Creating archetypes")
+    archetype_path = code_path.joinpath("archetypes")
+    _ensure_is_generated_dir(archetype_path)
+    archetype_all = []
+
+    def get_archetype(archetype_name: str) -> ClassDefinition | None:
+        if archetype_name in archetype_all:
+            return _ALL_CLASS_DEFS[game_id][archetype_name]
+
+        if parse_struct(archetype_name, property_archetypes[archetype_name], archetype_path, struct_fourcc=None):
+            archetype_all.append(archetype_name)
+            return _ALL_CLASS_DEFS[game_id][archetype_name]
+        return None
+
     known_enums: dict[str, EnumDefinition] = {_scrub_enum(e.name): e for e in _enums_by_game[game_id]}
 
     def get_prop_details(prop: dict) -> PropDetails:
@@ -1354,8 +1380,13 @@ def parse_game(templates_path: Path, game_xml: Path, game_id: str) -> dict:
             field_params["default_factory"] = prop_type
             from_json_code = f"{prop_type}.from_json({{obj}})"
             to_json_code = "{obj}.to_json()"
-            dependency_code = "{obj}.dependencies_for(asset_manager)"
             json_type = "json_util.JsonObject"
+
+            archetype = get_archetype(archetype_path)
+            if archetype is not None and not archetype.has_dependency_code():
+                dependency_code = None
+            else:
+                dependency_code = "{obj}.dependencies_for(asset_manager)"
 
             default_override = {}
             for inner_prop in prop["properties"]:
@@ -1829,18 +1860,13 @@ def parse_game(templates_path: Path, game_xml: Path, game_id: str) -> dict:
     getter_func += "    return _FOUR_CC_MAPPING[four_cc]\n"
     path.joinpath("__init__.py").write_text(getter_func)
 
-    print("> Creating archetypes")
-    path = code_path.joinpath("archetypes")
-    _ensure_is_generated_dir(path)
-
     base_import_path = f"retro_data_structures.properties.{_game_id_to_file[game_id]}.archetypes."
 
-    archetype_all = []
-    for archetype_name, archetype in property_archetypes.items():
-        if parse_struct(archetype_name, archetype, path, struct_fourcc=None):
-            archetype_all.append(archetype_name)
+    # Probably pointless?
+    for archetype_name in property_archetypes:
+        get_archetype(archetype_name)
 
-    create_all_file(path.joinpath("__init__.py"), base_import_path, archetype_all)
+    create_all_file(archetype_path.joinpath("__init__.py"), base_import_path, archetype_all)
 
     print("> Done.")
 

--- a/parse_pwe_templates.py
+++ b/parse_pwe_templates.py
@@ -763,7 +763,7 @@ class ClassDefinition:
         decoder_type = "typing.Callable[[typing.BinaryIO, int], typing.Any]"
         self.after_class_code += f"_property_decoder: dict[int, tuple[str, {decoder_type}]] = {{\n"
         for prop_name, prop in self.all_props.items():
-            self.after_class_code += f"    {hex(prop.id)}: ({repr(prop_name)}, {decode_names[prop_name]}),\n"
+            self.after_class_code += f"    0x{prop.id:08x}: ({repr(prop_name)}, {decode_names[prop_name]}),\n"
         self.after_class_code += "}\n"
 
     def write_to_stream(self) -> None:

--- a/parse_pwe_templates.py
+++ b/parse_pwe_templates.py
@@ -41,14 +41,37 @@ _game_id_to_enum = {
     "PrimeRemastered": "PRIME_REMASTER",
 }
 
+_STRUCTS: set[tuple[typing.Literal[">", "<"], str]] = set()
+_endianness_alias = {">": "BIG", "<": "LITTLE"}
+
+
+def _get_struct(endianness: typing.Literal[">", "<"], fmt: str) -> str:
+    _STRUCTS.add((endianness, fmt))
+    assert ">" not in fmt and "<" not in fmt, "Format should not include endianness"
+
+    fmt = fmt.replace("?", "bool_")
+
+    return f"{_endianness_alias[endianness]}_" + fmt
+
+
+def struct_unpack(endianness: typing.Literal[">", "<"], fmt: str) -> str:
+    final_fmt = endianness + fmt
+    return f'structs.{_get_struct(endianness, fmt)}.unpack(data.read({struct.calcsize(final_fmt)}))'
+
+
+def struct_pack(endianness: typing.Literal[">", "<"], fmt: str, code: str) -> str:
+    return f'structs.{_get_struct(endianness, fmt)}.pack({code})'
+
+
 _CODE_PARSE_UINT16 = {
-    ">": 'struct.unpack(">H", data.read(2))[0]',
-    "<": 'struct.unpack("<H", data.read(2))[0]',
+    ">": struct_unpack(">", "H") + "[0]",
+    "<": struct_unpack("<", "H") + "[0]",
 }
 _CODE_PARSE_UINT32 = {
-    ">": 'struct.unpack(">L", data.read(4))[0]',
-    "<": 'struct.unpack("<L", data.read(4))[0]',
+    ">": struct_unpack(">", "L") + "[0]",
+    "<": struct_unpack("<", "L") + "[0]",
 }
+
 
 RawPropType = typing.Literal[
     "Sound",
@@ -72,7 +95,7 @@ RawPropType = typing.Literal[
 ]
 
 
-def get_endianness(game_id: str) -> str:
+def get_endianness(game_id: str) -> typing.Literal[">", "<"]:
     return ">" if game_id != "PrimeRemastered" else "<"
 
 
@@ -112,7 +135,7 @@ class EnumDefinition:
         code += f"        return cls({_CODE_PARSE_UINT32[endianness]})\n"
 
         code += "\n    def to_stream(self, data: typing.BinaryIO) -> None:\n"
-        code += '        data.write(struct.pack("' + endianness + 'L", self.value))\n'
+        code += f'        data.write({struct_pack(endianness, "L", "self.value")})\n'
 
         code += "\n    @classmethod\n"
         code += "    def from_json(cls, data: json_util.JsonValue) -> typing_extensions.Self:\n"
@@ -139,6 +162,7 @@ def _scrub_enum(string: str) -> str:
 def create_enums_file(game_id: str, enums: dict[EnumDefinition, list[str]]) -> str:
     code = '"""\nGenerated file.\n"""\nimport enum\nimport typing\nimport struct\nimport typing_extensions\n'
     code += "\nfrom retro_data_structures import json_util\n"
+    code += "from retro_data_structures.properties import structs\n"
 
     for e, classes in enums.items():
         if len(classes) != 1:
@@ -567,7 +591,7 @@ class ClassDefinition:
             if prop.known_size is None:
                 build_prop.append("after = data.tell()")
                 build_prop.append("data.seek(before)")
-                build_prop.append(f'data.write(struct.pack("{endianness}H", after - before - 2))')
+                build_prop.append(f'data.write({struct_pack(endianness, "H", "after - before - 2")})')
                 build_prop.append("data.seek(after)")
 
             if not prop.custom_cook_pref:
@@ -678,7 +702,7 @@ class ClassDefinition:
                 variable_name += "_"
 
             # yield "    data.read(6)"  # TODO: assert correct
-            yield f'    property_id, property_size = struct.unpack("{endianness}LH", data.read(6))'
+            yield f'    property_id, property_size = {struct_unpack(endianness, "LH")}'
             yield f"    assert property_id == 0x{prop.id:08x}"
             yield f"    {variable_name} = {prop.parse_code}"
             yield ""
@@ -708,7 +732,7 @@ class ClassDefinition:
 
         if self.is_struct:
             self.class_code += (
-                '        struct_id, size, property_count = struct.unpack("' + endianness + 'LHH", data.read(8))\n'
+                f'        struct_id, size, property_count = {struct_unpack(endianness, "LHH")}\n'
             )
             self.class_code += "        assert struct_id == 0xFFFFFFFF\n"
             self.class_code += "        root_size_start = data.tell() - 2\n\n"
@@ -727,7 +751,7 @@ class ClassDefinition:
 
         self.class_code += f"""        present_fields = default_override or {{}}{unknown_fields_declare}
         for _ in range(property_count):
-            property_id, property_size = struct.unpack("{endianness}LH", data.read(6))
+            property_id, property_size = {struct_unpack(endianness, "LH")}
             start = data.tell()
             try:
                 property_name, decoder = _property_decoder[property_id]
@@ -1457,7 +1481,7 @@ def parse_game(templates_path: Path, game_xml: Path, game_id: str) -> dict:
                 prop_type = "int"
                 field_params["default"] = repr(default_value)
                 parse_code = _CODE_PARSE_UINT32[endianness]
-                build_code.append('data.write(struct.pack("' + endianness + 'L", {obj}))')
+                build_code.append(f'data.write({struct_pack(endianness, "L", "{obj}")})')
                 from_json_code = "{obj}"
                 to_json_code = "{obj}"
 
@@ -1490,7 +1514,7 @@ def parse_game(templates_path: Path, game_xml: Path, game_id: str) -> dict:
                 comment = "Flagset"
                 field_params["default"] = default_value
                 parse_code = _CODE_PARSE_UINT32[endianness]
-                build_code.append('data.write(struct.pack("' + endianness + 'L", {obj}))')
+                build_code.append(f'data.write({struct_pack(endianness, "L", "{obj}")})')
                 from_json_code = "{obj}"
                 to_json_code = "{obj}"
 
@@ -1521,14 +1545,11 @@ def parse_game(templates_path: Path, game_xml: Path, game_id: str) -> dict:
                 json_type = "int"
                 if game_id in ["Prime", "Echoes"]:
                     format_specifier = "L"
-                    known_size = 4
                 else:
                     format_specifier = "Q"
-                    known_size = 8
 
-                format_with_prefix = f'"{endianness}{format_specifier}"'
-                parse_code = f"struct.unpack({format_with_prefix}, data.read({known_size}))[0]"
-                build_code.append(f"data.write(struct.pack({format_with_prefix}, {{obj}}))")
+                parse_code = struct_unpack(endianness, format_specifier) + "[0]"
+                build_code.append(f"data.write({struct_pack(endianness, format_specifier, "{obj}")})")
                 from_json_code = "{obj}"
                 to_json_code = "{obj}"
 
@@ -1627,8 +1648,8 @@ def parse_game(templates_path: Path, game_xml: Path, game_id: str) -> dict:
             struct_format = endianness + literal_prop.struct_format
             format_specifier = literal_prop.struct_format
 
-            parse_code = f"struct.unpack({repr(struct_format)}, data.read({literal_prop.byte_count}))[0]"
-            build_code.append(f"data.write(struct.pack({repr(struct_format)}, {{obj}}))")
+            parse_code = struct_unpack(endianness, format_specifier) + "[0]"
+            build_code.append(f'data.write({struct_pack(endianness, format_specifier, "{obj}")})')
             from_json_code = "{obj}"
             to_json_code = "{obj}"
 
@@ -1772,6 +1793,7 @@ def parse_game(templates_path: Path, game_xml: Path, game_id: str) -> dict:
 
         code_code += "\nfrom retro_data_structures import json_util\n"
         code_code += "from retro_data_structures.game_check import Game\n"
+        code_code += "from retro_data_structures.properties import structs\n"
         code_code += f"from retro_data_structures.properties.base_property import {base_class}\n"
         code_code += "from retro_data_structures.properties.field_reflection import FieldReflection\n"
 
@@ -2005,6 +2027,11 @@ def write_shared_types_helpers(all_games: dict) -> None:
             for name in ["AnimationParameters", "AssetId", "Color", "Spline", "Vector"]
         },
     )
+    structs = "# Generated File\nimport struct\n\n"
+    for endianness, fmt_string in sorted(_STRUCTS):
+        structs += f'{_get_struct(endianness, fmt_string)} = struct.Struct("{endianness}{fmt_string}")\n'
+
+    path_to_props.joinpath("structs.py").write_text(structs)
 
 
 def parse(game_ids: typing.Iterable[str] | None = None) -> dict:

--- a/parse_pwe_templates.py
+++ b/parse_pwe_templates.py
@@ -42,6 +42,7 @@ _game_id_to_enum = {
 }
 
 _STRUCTS: set[tuple[typing.Literal[">", "<"], str]] = set()
+_DECODE_METHODS: dict[str, str] = {}
 _endianness_alias = {">": "BIG", "<": "LITTLE"}
 
 
@@ -786,9 +787,14 @@ class ClassDefinition:
                 suffix_size = len("(data, property_size)")
                 decode_names[prop_name] = prop.parse_code[:-suffix_size]
             else:
-                decode_names[prop_name] = f"_decode_{prop_name}"
-                self.after_class_code += f"def _decode_{prop_name}({signature}) -> {prop.prop_type}:\n"
-                self.after_class_code += f"    return {prop.parse_code}\n\n\n"
+                if prop.parse_code.startswith("structs.") and prop.parse_code.endswith("[0]"):
+                    split_code = prop.parse_code.split(".", 2)
+                    _DECODE_METHODS["decode_" + split_code[1]] = f"return {split_code[1]}.{split_code[2]}"
+                    decode_names[prop_name] = f"structs.decode_{split_code[1]}"
+                else:
+                    decode_names[prop_name] = f"_decode_{prop_name}"
+                    self.after_class_code += f"def _decode_{prop_name}({signature}) -> {prop.prop_type}:\n"
+                    self.after_class_code += f"    return {prop.parse_code}\n\n\n"
 
         decoder_type = "typing.Callable[[typing.BinaryIO, int], typing.Any]"
         self.after_class_code += f"_property_decoder: dict[int, tuple[str, {decoder_type}]] = {{\n"
@@ -2027,9 +2033,12 @@ def write_shared_types_helpers(all_games: dict) -> None:
             for name in ["AnimationParameters", "AssetId", "Color", "Spline", "Vector"]
         },
     )
-    structs = "# Generated File\nimport struct\n\n"
+    structs = "# Generated File\nimport struct\nimport typing\n\n"
     for endianness, fmt_string in sorted(_STRUCTS):
-        structs += f'{_get_struct(endianness, fmt_string)} = struct.Struct("{endianness}{fmt_string}")\n'
+        structs += f'{_get_struct(endianness, fmt=fmt_string)} = struct.Struct("{endianness}{fmt_string}")\n'
+    for decode_name, decode_body in sorted(_DECODE_METHODS.items()):
+        structs += f"\n\ndef {decode_name}(data: typing.BinaryIO, property_size: int):\n"
+        structs += f"    {decode_body}\n"
 
     path_to_props.joinpath("structs.py").write_text(structs)
 

--- a/parse_pwe_templates.py
+++ b/parse_pwe_templates.py
@@ -1557,7 +1557,7 @@ def parse_game(templates_path: Path, game_xml: Path, game_id: str) -> dict:
         elif raw_type == "Color" or raw_type == "Vector":
             prop_type = raw_type
             needed_imports[f"{import_base}.core.{raw_type}"] = prop_type
-            parse_code = f"{prop_type}.from_stream(data)"
+            parse_code = f"{prop_type}.from_stream(data, property_size)"
             build_code.append("{obj}.to_stream(data)")
             from_json_code = f"{prop_type}.from_json({{obj}})"
             to_json_code = "{obj}.to_json()"

--- a/parse_pwe_templates.py
+++ b/parse_pwe_templates.py
@@ -925,7 +925,11 @@ class ClassDefinition:
         if self.keep_unknown_properties() or self.game_id not in {"Prime", "Echoes"}:
             return
 
-        has_dep = False
+        if not self.is_struct and not self.has_dependency_code():
+            return
+
+        self.typing_imports["collections.abc"] = "Iterator"
+
         method_name = {}
 
         for prop_name, prop in self.all_props.items():
@@ -945,9 +949,10 @@ class ClassDefinition:
                 method_name[prop_name] = f"self._dependencies_for_{prop_name}"
 
                 self.class_code += f"""
-    def _dependencies_for_{prop_name}(self, asset_manager: AssetManager) -> typing.Iterator[Dependency]:
+    def _dependencies_for_{prop_name}(self, asset_manager: AssetManager) -> Iterator[Dependency]:
         {prop_code}
 """
+
         self.typing_imports["retro_data_structures.asset_manager"] = "AssetManager"
         self.typing_imports["retro_data_structures.base_resource"] = "Dependency"
 
@@ -959,7 +964,7 @@ class ClassDefinition:
             )
 
             self.class_code += f"""
-    def dependencies_for(self, asset_manager: AssetManager) -> typing.Iterator[Dependency]:
+    def dependencies_for(self, asset_manager: AssetManager) -> Iterator[Dependency]:
         for method, field_name, field_type in [
 {method_list}
         ]:
@@ -977,7 +982,7 @@ class ClassDefinition:
                 single_method = f"return {list(method_name.values())[0]}(asset_manager)"
 
             self.class_code += f"""
-    def dependencies_for(self, asset_manager: AssetManager) -> typing.Iterator[Dependency]:
+    def dependencies_for(self, asset_manager: AssetManager) -> Iterator[Dependency]:
         {single_method}
 """
 

--- a/src/retro_data_structures/properties/.gitignore
+++ b/src/retro_data_structures/properties/.gitignore
@@ -1,3 +1,4 @@
 /shared_archetypes.py
 /shared_core.py
 /shared_objects.py
+/structs.py

--- a/src/retro_data_structures/properties/base_property.py
+++ b/src/retro_data_structures/properties/base_property.py
@@ -6,11 +6,11 @@ import typing
 from abc import ABC
 
 if typing.TYPE_CHECKING:
-    import typing_extensions
+    from collections.abc import Iterator
 
     from retro_data_structures import json_util
     from retro_data_structures.asset_manager import AssetManager
-    from retro_data_structures.base_resource import AssetId, Dependency
+    from retro_data_structures.base_resource import Dependency
     from retro_data_structures.game_check import Game
 
 
@@ -21,11 +21,11 @@ class BaseProperty:
         raise NotImplementedError
 
     @classmethod
-    def from_stream(cls, data: typing.BinaryIO, size: int | None = None) -> typing_extensions.Self:
+    def from_stream(cls, data: typing.BinaryIO, size: int | None = None) -> typing.Self:
         raise NotImplementedError
 
     @classmethod
-    def from_bytes(cls, data: bytes) -> typing_extensions.Self:
+    def from_bytes(cls, data: bytes) -> typing.Self:
         stream = io.BytesIO(data)
         return cls.from_stream(stream, len(data))
 
@@ -38,47 +38,11 @@ class BaseProperty:
         return stream.getvalue()
 
     @classmethod
-    def from_json(cls, data: json_util.JsonValue) -> typing_extensions.Self:
+    def from_json(cls, data: json_util.JsonValue) -> typing.Self:
         raise NotImplementedError
 
     def to_json(self) -> json_util.JsonValue:
         raise NotImplementedError
-
-    def _is_property_mrea_or_mlvl(self, field: dataclasses.Field) -> bool:
-        asset_types = field.metadata.get("asset_types", [])
-        return any((typ in asset_types) for typ in ("MLVL", "MREA"))
-
-    def _dependencies_for_field(
-        self, field: dataclasses.Field, asset_manager: AssetManager
-    ) -> typing.Iterator[Dependency]:
-        field_type = field.type
-
-        if not isinstance(field_type, type):
-            # account for unions, string annotations, etc.
-            field_type = type(getattr(self, field.name))
-
-        if issubclass(field_type, BaseProperty):
-            prop: BaseProperty = getattr(self, field.name)
-            yield from prop.dependencies_for(asset_manager)
-
-        elif issubclass(field_type, int) and "sound" in field.metadata:
-            sound_id: int = getattr(self, field.name)
-            yield from asset_manager.get_audio_group_dependency(sound_id)
-
-        elif issubclass(field_type, int) and (field.default == 0xFFFFFFFF or "asset_types" in field.metadata):
-            if self._is_property_mrea_or_mlvl(field):
-                return
-            asset_id: AssetId = getattr(self, field.name)
-            yield from asset_manager.get_dependencies_for_asset(asset_id)
-
-    def dependencies_for(self, asset_manager: AssetManager) -> typing.Iterator[Dependency]:
-        for field in dataclasses.fields(self):
-            try:
-                yield from self._dependencies_for_field(field, asset_manager)
-            except Exception as e:
-                raise Exception(
-                    f"Error finding dependencies for {self.__class__.__name__}.{field.name} ({field.type}): {e}"
-                )
 
 
 class BaseObjectType(BaseProperty, ABC):
@@ -94,4 +58,7 @@ class BaseObjectType(BaseProperty, ABC):
         raise NotImplementedError
 
     def set_name(self, name: str) -> None:
+        raise NotImplementedError
+
+    def dependencies_for(self, asset_manager: AssetManager) -> Iterator[Dependency]:
         raise NotImplementedError

--- a/tests/properties/test_base_property.py
+++ b/tests/properties/test_base_property.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import dataclasses
 
-from retro_data_structures.properties.base_property import BaseProperty
 from retro_data_structures.properties.echoes.archetypes.Vector2f import Vector2f
+
+from retro_data_structures.properties.base_property import BaseProperty
 from retro_data_structures.properties.field_reflection import FieldReflection, get_reflection
 
 

--- a/tests/properties/test_base_property.py
+++ b/tests/properties/test_base_property.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import dataclasses
 
-from retro_data_structures.properties.echoes.archetypes.Vector2f import Vector2f
-
 from retro_data_structures.properties.base_property import BaseProperty
+from retro_data_structures.properties.echoes.archetypes.Vector2f import Vector2f
 from retro_data_structures.properties.field_reflection import FieldReflection, get_reflection
 
 
@@ -51,24 +50,6 @@ class DummyProperty(BaseProperty):
             )
         },
     )
-
-
-def test_dependencies(prime2_asset_manager):
-    from retro_data_structures.base_resource import Dependency
-
-    dummy = DummyProperty(
-        Vector2f(),
-        0xFFFFFFFF,
-        1,
-        0x07E36D6F,  # some random RULE
-    )
-
-    dependencies = list(dummy.dependencies_for(prime2_asset_manager))
-    assert dependencies == [
-        Dependency("AGSC", 0xC8739BEC),
-        Dependency("RULE", 0x9C1232E2),
-        Dependency("RULE", 0x07E36D6F),
-    ]
 
 
 def test_get_reflection():


### PR DESCRIPTION
- Avoid calling empty `dependencies_for` methods
- Use shared instances of `Struct` for packing/unpacking
- Less helper methods for `_property_decoders`