### PR TITLE
fix `remove_instance()` being too strict when given a direct ID

### DIFF
--- a/src/retro_data_structures/formats/script_layer.py
+++ b/src/retro_data_structures/formats/script_layer.py
@@ -217,7 +217,7 @@ class ScriptLayer:
             instance = self._get_instance_by_name(instance)
         instance = resolve_instance_id(instance)
 
-        matching_instances = [i for i in self._raw.script_instances if i.id == instance]
+        matching_instances = [i for i in self._raw.script_instances if instance.matches(i.id)]
 
         if not matching_instances:
             raise KeyError(instance)

--- a/tests/formats/test_script_api.py
+++ b/tests/formats/test_script_api.py
@@ -169,6 +169,9 @@ def test_remove_instance(prime2_area: Area):
     prime2_area.remove_instance("Pickup Object")
     assert len(list(prime2_area.all_instances)) == old_len - 1
 
+    prime2_area.remove_instance(0x1045006C)  # Deactivate Pickup (incorrect layer ID)
+    assert len(list(prime2_area.all_instances)) == old_len - 2
+
 
 def test_move_instance(prime2_area: Area):
     idx = 0x0045006B


### PR DESCRIPTION
now it behaves like `get_instance()` does