### PR TITLE
fix handling of multiple instances in script API

### DIFF
--- a/src/retro_data_structures/formats/mrea.py
+++ b/src/retro_data_structures/formats/mrea.py
@@ -39,7 +39,7 @@ from retro_data_structures.formats.area_collision import AreaCollision
 from retro_data_structures.formats.arot import AROT
 from retro_data_structures.formats.cmdl import dependencies_for_material_set
 from retro_data_structures.formats.lights import Lights
-from retro_data_structures.formats.script_layer import SCGN, SCLY, ScriptLayer, new_layer
+from retro_data_structures.formats.script_layer import SCGN, SCLY, MultipleInstances, ScriptLayer, new_layer
 from retro_data_structures.formats.script_object import Connection, InstanceId, InstanceIdRef
 from retro_data_structures.formats.strg import Strg
 from retro_data_structures.formats.visi import VISI
@@ -821,25 +821,47 @@ class Area:
         """
         Gets the instance with the given name or id.
         :param ref:
-        :raises KeyError: if instance is not found, or if multiple instances have the given name.
+        :raises KeyError: if instance is not found
+        :raises MultipleInstances: if multiple instances have the given name
         :return:
         """
+        results: list[ScriptInstance] = []
         for layer in self.all_layers:
             try:
-                return layer.get_instance(ref)
+                results.append(layer.get_instance(ref))
             except KeyError:
                 pass
-        raise KeyError(ref)
+        if not results:
+            raise KeyError(ref)
+        if len(results) > 1:
+            raise MultipleInstances(f"non-unique name {ref}")
+        return results[0]
 
-    def remove_instance(self, instance: InstanceRef):
+    def _remove_instances(self, instance: InstanceRef, *, allow_multiple: bool) -> None:
+        try:
+            instance = self.get_instance(instance)
+        except MultipleInstances:
+            if not allow_multiple:
+                raise MultipleInstances(f"non-unique name {instance}")
+        except KeyError:
+            raise KeyError(instance)
+
         for layer in self.all_layers:
             try:
-                layer.remove_instance(instance)
+                if allow_multiple:
+                    layer.remove_instances(instance)
+                else:
+                    layer.remove_instance(instance)
             except KeyError:
                 pass
-            else:
-                return
-        raise KeyError(instance)
+
+    def remove_instance(self, instance: InstanceRef) -> None:
+        """Remove the given instance from this area."""
+        self._remove_instances(instance, allow_multiple=False)
+
+    def remove_instances(self, instance: InstanceRef) -> None:
+        """Remove all matching instances from this area."""
+        self._remove_instances(instance, allow_multiple=True)
 
     def move_instance(self, instance: InstanceRef, new_layer: str) -> None:
         """
@@ -851,7 +873,10 @@ class Area:
         new_inst.id = InstanceId.new(new_inst.id.layer, new_inst.id.area, old_inst.id.instance)
         for inst in self.all_instances:
             inst.replace_connections_to(old_inst, new_inst)
-        self.remove_instance(old_inst)
+
+        # remove the instance from the old layer specifically
+        old_layer = next(layer for layer in self.all_layers if any(inst.id == old_inst.id for inst in layer.instances))
+        old_layer.remove_instance(old_inst)
 
     def get_all_connections_to(self, target: InstanceIdRef) -> list[tuple[ScriptInstance, Connection]]:
         """

--- a/src/retro_data_structures/formats/script_layer.py
+++ b/src/retro_data_structures/formats/script_layer.py
@@ -95,6 +95,10 @@ SCLY = IfThenElse(
 SCGN = ConstructScriptLayer("SCGN")
 
 
+class MultipleInstances(Exception):
+    pass
+
+
 def dependencies_for_layer(
     asset_manager: AssetManager, instances: typing.Iterable[ScriptInstance]
 ) -> typing.Iterator[Dependency]:
@@ -183,7 +187,7 @@ class ScriptLayer:
     def _get_instance_by_name(self, name: str) -> ScriptInstance:
         all_instances = self.get_all_instances_with_name(name)
         if len(all_instances) > 1:
-            raise KeyError(f"non-unique name `{name}`")
+            raise MultipleInstances(f"non-unique name `{name}`")
         elif not all_instances:
             raise KeyError(name)
         return all_instances[0]
@@ -212,13 +216,15 @@ class ScriptLayer:
         savw.raw.memory_relays.append(SavedStateDescriptor(relay.id))
         return relay
 
-    def remove_instance(self, instance: InstanceRef) -> None:
+    def _remove_instances(self, instance: InstanceRef, *, allow_multiple: bool) -> None:
         if isinstance(instance, str):
             instance = self._get_instance_by_name(instance)
         instance = resolve_instance_id(instance)
 
         matching_instances = [i for i in self._raw.script_instances if instance.matches(i.id)]
 
+        if not allow_multiple and len(matching_instances) > 1:
+            raise MultipleInstances(f"Instance is not unique: {instance}")
         if not matching_instances:
             raise KeyError(instance)
 
@@ -226,7 +232,15 @@ class ScriptLayer:
         for i in matching_instances:
             self._raw.script_instances.remove(i)
 
-    def remove_instances(self) -> None:
+    def remove_instance(self, instance: InstanceRef) -> None:
+        """Remove the given instance from this layer."""
+        self._remove_instances(instance, allow_multiple=False)
+
+    def remove_instances(self, instance: InstanceRef) -> None:
+        """Remove all matching instances from this layer."""
+        self._remove_instances(instance, allow_multiple=True)
+
+    def remove_all_instances(self) -> None:
         self.mark_modified()
         self._raw.script_instances = []
 

--- a/tests/formats/test_script_api.py
+++ b/tests/formats/test_script_api.py
@@ -163,6 +163,9 @@ def test_get_instance(prime2_area: Area):
     inst = prime2_area.get_instance(name)
     assert inst.id == idx
 
+    with pytest.raises(KeyError):
+        inst = prime2_area.get_instance(0)
+
 
 def test_remove_instance(prime2_area: Area):
     old_len = len(list(prime2_area.all_instances))
@@ -171,6 +174,16 @@ def test_remove_instance(prime2_area: Area):
 
     prime2_area.remove_instance(0x1045006C)  # Deactivate Pickup (incorrect layer ID)
     assert len(list(prime2_area.all_instances)) == old_len - 2
+
+    with pytest.raises(KeyError):
+        prime2_area.remove_instance(0)
+
+
+def test_remove_all_instances(prime2_area):
+    for layer in prime2_area.all_layers:
+        layer.remove_all_instances()
+
+    assert not list(prime2_area.all_instances)
 
 
 def test_move_instance(prime2_area: Area):
@@ -351,6 +364,14 @@ def test_multiple_instances(prime2_asset_manager):
     # Trooper Security Station
     area = prime2_asset_manager.get_file(0x3BFA3EFF, Mlvl).get_area(0x55EE6DC3)
 
+    # same layer
+    with pytest.raises(MultipleInstances):
+        area.get_instance("Sound - Missile")
+
+    with pytest.raises(MultipleInstances):
+        area.remove_instance("Sound - Missile")
+
+    # different layers
     with pytest.raises(MultipleInstances):
         area.get_instance("Music Player For Area")
 

--- a/tests/formats/test_script_api.py
+++ b/tests/formats/test_script_api.py
@@ -6,14 +6,14 @@ import pytest
 
 import retro_data_structures.enums.echoes as _echoes_enums
 import retro_data_structures.enums.prime as _prime_enums
-from retro_data_structures.formats import script_object
-from retro_data_structures.formats.script_layer import SCLY
+from retro_data_structures.formats import Mlvl, script_object
+from retro_data_structures.formats.script_layer import SCLY, MultipleInstances
 from retro_data_structures.formats.script_object import Connection, InstanceId
 from retro_data_structures.game_check import Game
 from retro_data_structures.properties.echoes.core import Vector
 
 if TYPE_CHECKING:
-    from retro_data_structures.formats.mlvl import Area, Mlvl
+    from retro_data_structures.formats.mlvl import Area
 
 
 @pytest.fixture()
@@ -345,3 +345,19 @@ def test_roundtrip_prime1(prime1_scly_raw: bytes) -> None:
     encoded = SCLY.build(decoded, target_game=Game.PRIME)
 
     assert prime1_scly_raw == encoded
+
+
+def test_multiple_instances(prime2_asset_manager):
+    # Trooper Security Station
+    area = prime2_asset_manager.get_file(0x3BFA3EFF, Mlvl).get_area(0x55EE6DC3)
+
+    with pytest.raises(MultipleInstances):
+        area.get_instance("Music Player For Area")
+
+    with pytest.raises(MultipleInstances):
+        area.remove_instance("Music Player For Area")
+
+    old_len = len(list(area.all_instances))
+    area.remove_instances("Music Player For Area")
+
+    assert len(list(area.all_instances)) == old_len - 3


### PR DESCRIPTION
`get_instance()`, `move_instance()`, `remove_instance()` were all handling this incorrectly and sometimes causing errors